### PR TITLE
diskv: add a cancel channel on Keys & KeysPrefix

### DIFF
--- a/basic_test.go
+++ b/basic_test.go
@@ -95,7 +95,8 @@ func TestStrings(t *testing.T) {
 		}
 	}
 
-	for k := range d.Keys() {
+	done := make(chan struct{})
+	for k := range d.Keys(done) {
 		if _, present := keys[k]; present {
 			t.Logf("got: %s", k)
 			keys[k] = true

--- a/examples/content-addressable-store/cas.go
+++ b/examples/content-addressable-store/cas.go
@@ -43,7 +43,8 @@ func main() {
 	}
 
 	var keyCount int
-	for key := range d.Keys() {
+	done := make(chan struct{})
+	for key := range d.Keys(done) {
 		val, err := d.Read(key)
 		if err != nil {
 			panic(fmt.Sprintf("key %s had no value", key))


### PR DESCRIPTION
A user might want to cancel the iteration through keys early. Enable the
user to do this.
