### PR TITLE
Import: don't fail for cross-device imports

### DIFF
--- a/diskv.go
+++ b/diskv.go
@@ -166,12 +166,9 @@ func (d *Diskv) writeStreamWithLock(key string, r io.Reader, sync bool) error {
 	return nil
 }
 
-// Import will import the source file into diskv under the destination key. If
-// the destination key already exists, it will be overwritten.
-//
-// If move is true, diskv will perform a mv, which is zero-copy and atomic
-// provided the source file is on the same filesystem. If move is false,
-// Import invokes WriteStream, using the source file as the reader.
+// Import imports the source file into diskv under the destination key. If the
+// destination key already exists, it's overwritten. If move is true, the
+// source file is removed after a successful import.
 func (d *Diskv) Import(srcFilename, dstKey string, move bool) (err error) {
 	if dstKey == "" {
 		return errEmptyKey
@@ -191,10 +188,11 @@ func (d *Diskv) Import(srcFilename, dstKey string, move bool) (err error) {
 	}
 
 	if move {
-		d.bustCacheWithLock(dstKey)
-		err := syscall.Rename(srcFilename, d.completeFilename(dstKey))
-		// If it failed due to being on a different device, fall back to copying
-		if err != syscall.EXDEV {
+		if err := syscall.Rename(srcFilename, d.completeFilename(dstKey)); err == nil {
+			d.bustCacheWithLock(dstKey)
+			return nil
+		} else if err != syscall.EXDEV {
+			// If it failed due to being on a different device, fall back to copying
 			return err
 		}
 	}


### PR DESCRIPTION
rename(2) only works on a single device. When trying to import a file
(with move=true) from a different device to the one on which the diskv is
located, we should gracefully fall back to copying the file and then removing
it (like mv(1) does).

@peterbourgon This is a little awkward to test, because we don't want to start making assumptions about filesystems; but rest assured it works, and the reason I know that is because before this diff the tests fail on my laptop ;-) (since tmpfs is a separate filesystem)
