### PR TITLE
KeysPrefix: do not transform empty prefix

### DIFF
--- a/diskv.go
+++ b/diskv.go
@@ -393,11 +393,18 @@ func (d *Diskv) Keys(cancel <-chan struct{}) <-chan string {
 
 // KeysPrefix returns a channel that will yield every key accessible by the
 // store with the given prefix, in undefined order. If a cancel channel is
-// provided, closing it will terminate and close the keys channel.
+// provided, closing it will terminate and close the keys channel. If the
+// provided prefix is the empty string, all keys will be yielded.
 func (d *Diskv) KeysPrefix(prefix string, cancel <-chan struct{}) <-chan string {
+	var prepath string
+	if prefix == "" {
+		prepath = d.BasePath
+	} else {
+		prepath = d.pathFor(prefix)
+	}
 	c := make(chan string)
 	go func() {
-		filepath.Walk(d.pathFor(prefix), walker(c, prefix, cancel))
+		filepath.Walk(prepath, walker(c, prefix, cancel))
 		close(c)
 	}()
 	return c

--- a/keys_test.go
+++ b/keys_test.go
@@ -20,6 +20,7 @@ var (
 	}
 
 	prefixes = []string{
+		"", // all
 		"a",
 		"ab",
 		"ab0",
@@ -42,8 +43,15 @@ var (
 )
 
 func TestKeysFlat(t *testing.T) {
+	transform := func(s string) []string {
+		if s == "" {
+			t.Fatalf(`transform should not be called with ""`)
+		}
+		return []string{}
+	}
 	d := diskv.New(diskv.Options{
-		BasePath: "test-data",
+		BasePath:  "test-data",
+		Transform: transform,
 	})
 	defer d.EraseAll()
 


### PR DESCRIPTION
When KeysPrefix was introduced, the behaviour of Keys was changed: rather than
just walking from BasePath, it attempted to transform the empty prefix using
the configured BlockTransform. I do not think this is correct behaviour; it
just happened to be fine in the default case because the default transform
used in tests would simply return an empty slice, which means pathFor() would
end up returning BasePath anyway. However, BlockTransform functions should
arguably not be expected to successfully transform an empty key into an empty
slice (ours actually panics in that scenario which is how I noticed this ;-)
