### PR TITLE
ReadStream: never siphon if CacheMaxSize <= 0

### DIFF
--- a/diskv.go
+++ b/diskv.go
@@ -299,7 +299,7 @@ type closingReader struct {
 	rc io.ReadCloser
 }
 
-func (cr *closingReader) Read(p []byte) (int, error) {
+func (cr closingReader) Read(p []byte) (int, error) {
 	n, err := cr.rc.Read(p)
 	if err == io.EOF {
 		if closeErr := cr.rc.Close(); closeErr != nil {


### PR DESCRIPTION
If the user has not set a CacheMaxSize >0, we should never attempt to start
siphoning values while reading objects.

@peterbourgon This is the absolutely minimally invasive change I could come up with to implement this without various other knock-on changes (for example, tweaking the Compression interfaces to work with ReadClosers, etc). It's a little weird to have to introduce the closingReader but I did it that way to essentially preserve the same behaviour of the siphon closing the file on EOF. 

An alternative would be changing the `ReadStream` interface to return a `ReadCloser`, and insist that the user closes the object when done with it (and that would close the underlying file). Not sure how you feel about going in that direction.
