### PR TITLE
Create a new "TempDir" option for atomic write

### DIFF
--- a/diskv.go
+++ b/diskv.go
@@ -46,7 +46,12 @@ type Options struct {
 	CacheSizeMax uint64 // bytes
 	PathPerm     os.FileMode
 	FilePerm     os.FileMode
-	TempDir      string
+	// If TempDir is set, it will enable filesystem atomic writes by
+	// writing temporary files to that location before being moved
+	// to BasePath.
+	// Note that TempDir MUST be on the same device/partition as
+	// BasePath.
+	TempDir string
 
 	Index     Index
 	IndexLess LessFunction


### PR DESCRIPTION
The current atomic write is somewhat broken as the temporary files are
created inside the base directory, and so count as potential keys (and
can conflict). Move these temporary files in the TempDir specified by
the user so that they can't conflict with future keys.

Note that the TempDir must be on the same device/partition/mount or the
atomic Rename will fail across partition.

Atomic write will not happen if TempDir is left empty.