### PR TITLE
Return a bad key error when a key contains the path separator

### DIFF
--- a/diskv.go
+++ b/diskv.go
@@ -115,6 +115,11 @@ func (d *Diskv) WriteStream(key string, r io.Reader, sync bool) error {
 		return errEmptyKey
 	}
 
+	// Ensure keys cannot evaluate to paths that would not exist
+	if strings.ContainsRune(key, os.PathSeparator) {
+		return errBadKey
+	}
+
 	d.mu.Lock()
 	defer d.mu.Unlock()
 

--- a/index_test.go
+++ b/index_test.go
@@ -146,3 +146,21 @@ func TestIndexKeysEmptyFrom(t *testing.T) {
 		t.Errorf("want %v, have %v", want, have)
 	}
 }
+
+func TestBadKeys(t *testing.T) {
+	d := New(Options{
+		BasePath:     "index-test",
+		Transform:    func(string) []string { return []string{} },
+		CacheSizeMax: 1024,
+		Index:        &BTreeIndex{},
+		IndexLess:    strLess,
+	})
+	defer d.EraseAll()
+
+	for _, k := range []string{"a/a"} {
+		err := d.Write(k, []byte("1"))
+		if err != errBadKey {
+			t.Errorf("Expected bad key error, got: %v", err)
+		}
+	}
+}


### PR DESCRIPTION
Provides an idea of what might be wrong.