### PR TITLE
Use bytes.Reader instead of bytes.Buffer

### DIFF
--- a/diskv.go
+++ b/diskv.go
@@ -102,7 +102,7 @@ func New(o Options) *Diskv {
 // available for reads. Write relies on the filesystem to perform an eventual
 // sync to physical media. If you need stronger guarantees, see WriteStream.
 func (d *Diskv) Write(key string, val []byte) error {
-	return d.WriteStream(key, bytes.NewBuffer(val), false)
+	return d.WriteStream(key, bytes.NewReader(val), false)
 }
 
 // WriteStream writes the data represented by the io.Reader to the disk, under
@@ -287,7 +287,7 @@ func (d *Diskv) ReadStream(key string, direct bool) (io.ReadCloser, error) {
 
 	if val, ok := d.cache[key]; ok {
 		if !direct {
-			buf := bytes.NewBuffer(val)
+			buf := bytes.NewReader(val)
 			if d.Compression != nil {
 				return d.Compression.Reader(buf)
 			}


### PR DESCRIPTION
In some places a `*bytes.Buffer` is used where a `*bytes.Reader` would be suitable.

A `bytes.Buffer` is a 102-byte struct while a `bytes.Reader` is merely 38-bytes in size. By replacing these uses the amount of memory allocated in certain cases is reduced.

```
name                    old alloc/op   new alloc/op   delta
Write__32B_NoIndex-8        544B ± 0%      480B ± 0%  -11.76%  (p=0.008 n=5+5)
Write__1KB_NoIndex-8        544B ± 0%      480B ± 0%  -11.76%  (p=0.008 n=5+5)
Write__4KB_NoIndex-8        544B ± 0%      480B ± 0%  -11.76%  (p=0.008 n=5+5)
Write_10KB_NoIndex-8        544B ± 0%      480B ± 0%  -11.76%  (p=0.008 n=5+5)
Write__32B_WithIndex-8      579B ± 0%      515B ± 0%  -11.05%  (p=0.008 n=5+5)
Write__1KB_WithIndex-8      579B ± 0%      515B ± 0%  -11.05%  (p=0.008 n=5+5)
Write__4KB_WithIndex-8      579B ± 0%      515B ± 0%  -11.05%  (p=0.008 n=5+5)
Write_10KB_WithIndex-8      581B ± 0%      517B ± 0%  -11.02%  (p=0.008 n=5+5)
Read__32B_NoCache-8       2.45kB ± 0%    2.45kB ± 0%     ~     (all equal)
Read__1KB_NoCache-8       2.45kB ± 0%    2.45kB ± 0%     ~     (all equal)
Read__4KB_NoCache-8       14.7kB ± 0%    14.7kB ± 0%     ~     (all equal)
Read_10KB_NoCache-8       31.1kB ± 0%    31.1kB ± 0%     ~     (all equal)
Read__32B_WithCache-8     2.18kB ± 0%    2.11kB ± 0%   -2.94%  (p=0.008 n=5+5)
Read__1KB_WithCache-8     2.18kB ± 0%    2.12kB ± 0%   -2.88%  (p=0.000 n=5+4)
Read__4KB_WithCache-8     14.5kB ± 0%    14.4kB ± 0%   -0.44%  (p=0.008 n=5+5)
Read_10KB_WithCache-8     40.3kB ± 0%    40.3kB ± 0%     ~     (p=0.452 n=5+5)

name                    old allocs/op  new allocs/op  delta
Write__32B_NoIndex-8        13.0 ± 0%      13.0 ± 0%     ~     (all equal)
Write__1KB_NoIndex-8        13.0 ± 0%      13.0 ± 0%     ~     (all equal)
Write__4KB_NoIndex-8        13.0 ± 0%      13.0 ± 0%     ~     (all equal)
Write_10KB_NoIndex-8        13.0 ± 0%      13.0 ± 0%     ~     (all equal)
Write__32B_WithIndex-8      14.0 ± 0%      14.0 ± 0%     ~     (all equal)
Write__1KB_WithIndex-8      14.0 ± 0%      14.0 ± 0%     ~     (all equal)
Write__4KB_WithIndex-8      14.0 ± 0%      14.0 ± 0%     ~     (all equal)
Write_10KB_WithIndex-8      14.0 ± 0%      14.0 ± 0%     ~     (all equal)
Read__32B_NoCache-8         12.0 ± 0%      12.0 ± 0%     ~     (all equal)
Read__1KB_NoCache-8         12.0 ± 0%      12.0 ± 0%     ~     (all equal)
Read__4KB_NoCache-8         14.0 ± 0%      14.0 ± 0%     ~     (all equal)
Read_10KB_NoCache-8         15.0 ± 0%      15.0 ± 0%     ~     (all equal)
Read__32B_WithCache-8       4.00 ± 0%      4.00 ± 0%     ~     (all equal)
Read__1KB_WithCache-8       4.00 ± 0%      4.00 ± 0%     ~     (all equal)
Read__4KB_WithCache-8       6.00 ± 0%      6.00 ± 0%     ~     (all equal)
Read_10KB_WithCache-8       11.0 ± 0%      11.0 ± 0%     ~     (all equal)
```