### PR TITLE
support for slashes in key names and advanced key transformation

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,55 @@ always flatly available on the disk. diskv will never do anything that would
 prevent you from accessing, copying, backing up, or otherwise interacting with
 your data via common UNIX commandline tools.
 
+## Advanced path transformation
+
+If you need more control over the file name written to disk or if you want to support
+slashes in your key name or special characters in the keys, you can use the
+AdvancedTransform property. You must supply a function that returns
+a special PathKey structure, which is a breakdown of a path and a file name. Strings
+returned must be clean of any slashes or special characters:
+
+```go
+func AdvancedTransformExample (key string) *diskv.PathKey {
+	path := strings.Split(key,"/")
+	last := len(path)-1
+	return &diskv.PathKey{
+		Path: path[:last],
+		FileName: path[last] + ".txt"
+	}
+}
+
+// If you provide an AdvancedTransform, you must also provide its
+// inverse:
+
+func InverseTransformExample (pathKey *diskv.PathKey) (key string){
+	txt := pathKey.FileName[len(pathKey.FileName-4):]
+	if txt != ".txt" {
+		panic("Invalid file found in storage folder!")
+	}
+	key = strings.Join(pathKey.Path, "/") + pathKey.FileName[:len(pathKey.FileName-4)]
+	return
+}
+
+func main() {
+
+	d := diskv.New(diskv.Options{
+		BasePath:     "my-data-dir",
+		AdvancedTransform:    AdvancedTransformExample,
+		InverseTransform: InverseTransformExample,
+		CacheSizeMax: 1024 * 1024,
+	})
+
+
+	// Write three bytes to the key "alpha/beta/gamma".
+	key := "alpha/beta/gamma"
+	d.Write(key, []byte{'1', '2', '3'}) // will be stored in "<basedir>/alpha/beta/gamma.txt"
+
+}
+
+```
+
+
 ## Adding a cache
 
 An in-memory caching layer is provided by combining the BasicStore
@@ -139,3 +188,9 @@ data to be handled efficiently.
  * Needs plenty of robust testing: huge datasets, etc...
  * More thorough benchmarking
  * Your suggestions for use-cases I haven't thought of
+
+
+# Credits and contributions
+
+Original idea, design and implementation: [Peter Bourgon][https://github.com/peterbourgon]
+Other collaborations: [Javier Peletier][https://github.com/jpeletier] ([Epic Labs][https://www.epiclabs.io])

--- a/README.md
+++ b/README.md
@@ -129,27 +129,21 @@ func InverseTransformExample(pathKey *diskv.PathKey) (key string) {
 	if txt != ".txt" {
 		panic("Invalid file found in storage folder!")
 	}
-	key = strings.Join(pathKey.Path, "/") + pathKey.FileName[:len(pathKey.FileName)-4]
-	return
+	return strings.Join(pathKey.Path, "/") + pathKey.FileName[:len(pathKey.FileName)-4]
 }
 
 func main() {
-
 	d := diskv.New(diskv.Options{
 		BasePath:          "my-data-dir",
 		AdvancedTransform: AdvancedTransformExample,
 		InverseTransform:  InverseTransformExample,
 		CacheSizeMax:      1024 * 1024,
 	})
-
 	// Write some text to the key "alpha/beta/gamma".
 	key := "alpha/beta/gamma"
 	d.WriteString(key, "¡Hola!") // will be stored in "<basedir>/alpha/beta/gamma.txt"
-
 	fmt.Println(d.ReadString("alpha/beta/gamma"))
-
 }
-
 ```
 
 
@@ -193,5 +187,5 @@ data to be handled efficiently.
 
 # Credits and contributions
 
-Original idea, design and implementation: [Peter Bourgon][https://github.com/peterbourgon]
-Other collaborations: [Javier Peletier][https://github.com/jpeletier] ([Epic Labs][https://www.epiclabs.io])
+Original idea, design and implementation: [Peter Bourgon](https://github.com/peterbourgon)
+Other collaborations: [Javier Peletier](https://github.com/jpeletier) ([Epic Labs](https://www.epiclabs.io))

--- a/README.md
+++ b/README.md
@@ -112,40 +112,41 @@ a special PathKey structure, which is a breakdown of a path and a file name. Str
 returned must be clean of any slashes or special characters:
 
 ```go
-func AdvancedTransformExample (key string) *diskv.PathKey {
-	path := strings.Split(key,"/")
-	last := len(path)-1
+func AdvancedTransformExample(key string) *diskv.PathKey {
+	path := strings.Split(key, "/")
+	last := len(path) - 1
 	return &diskv.PathKey{
-		Path: path[:last],
-		FileName: path[last] + ".txt"
+		Path:     path[:last],
+		FileName: path[last] + ".txt",
 	}
 }
 
 // If you provide an AdvancedTransform, you must also provide its
 // inverse:
 
-func InverseTransformExample (pathKey *diskv.PathKey) (key string){
-	txt := pathKey.FileName[len(pathKey.FileName-4):]
+func InverseTransformExample(pathKey *diskv.PathKey) (key string) {
+	txt := pathKey.FileName[len(pathKey.FileName)-4:]
 	if txt != ".txt" {
 		panic("Invalid file found in storage folder!")
 	}
-	key = strings.Join(pathKey.Path, "/") + pathKey.FileName[:len(pathKey.FileName-4)]
+	key = strings.Join(pathKey.Path, "/") + pathKey.FileName[:len(pathKey.FileName)-4]
 	return
 }
 
 func main() {
 
 	d := diskv.New(diskv.Options{
-		BasePath:     "my-data-dir",
-		AdvancedTransform:    AdvancedTransformExample,
-		InverseTransform: InverseTransformExample,
-		CacheSizeMax: 1024 * 1024,
+		BasePath:          "my-data-dir",
+		AdvancedTransform: AdvancedTransformExample,
+		InverseTransform:  InverseTransformExample,
+		CacheSizeMax:      1024 * 1024,
 	})
 
-
-	// Write three bytes to the key "alpha/beta/gamma".
+	// Write some text to the key "alpha/beta/gamma".
 	key := "alpha/beta/gamma"
-	d.Write(key, []byte{'1', '2', '3'}) // will be stored in "<basedir>/alpha/beta/gamma.txt"
+	d.WriteString(key, "¡Hola!") // will be stored in "<basedir>/alpha/beta/gamma.txt"
+
+	fmt.Println(d.ReadString("alpha/beta/gamma"))
 
 }
 

--- a/basic_test.go
+++ b/basic_test.go
@@ -3,6 +3,9 @@ package diskv
 import (
 	"bytes"
 	"errors"
+	"math/rand"
+	"regexp"
+	"strings"
 	"testing"
 	"time"
 )
@@ -333,4 +336,83 @@ func TestAtomicWrite(t *testing.T) {
 	if _, ok := <-d.Keys(nil); ok {
 		t.Fatal("Store isn't empty")
 	}
+}
+
+func TestHybridStore(t *testing.T) {
+	var regex *regexp.Regexp = regexp.MustCompile("[0-9a-fA-F]{64}")
+
+	transformFunc := func(s string) *PathKey {
+
+		if regex.MatchString(s) {
+			return &PathKey{Path: []string{"objects", s[0:2]},
+				FileName: s,
+			}
+		}
+
+		folders := strings.Split(s, "/")
+		lfolders := len(folders)
+		if lfolders > 1 {
+			return &PathKey{Path: folders[:lfolders-1],
+				FileName: folders[lfolders-1],
+			}
+		}
+
+		return &PathKey{Path: []string{},
+			FileName: s,
+		}
+	}
+
+	inverseTransformFunc := func(pathKey *PathKey) string {
+
+		if regex.MatchString(pathKey.FileName) {
+			return pathKey.FileName
+
+		}
+
+		if len(pathKey.Path) == 0 {
+			return pathKey.FileName
+		}
+
+		return strings.Join(pathKey.Path, "/") + "/" + pathKey.FileName
+
+	}
+	opts := Options{
+		BasePath:         "test-data",
+		CacheSizeMax:     1024,
+		Transform:        transformFunc,
+		InverseTransform: inverseTransformFunc,
+	}
+	d := New(opts)
+	defer d.EraseAll()
+
+	testData := map[string]string{}
+
+	for i := 0; i < 100; i++ {
+		testData[RandStringBytes(64)] = RandStringBytes(100)
+	}
+
+	for i := 0; i < 100; i++ {
+		testData[RandStringBytes(20)] = RandStringBytes(100)
+	}
+
+	for i := 0; i < 100; i++ {
+		numsep := rand.Intn(10) + 1
+		key := ""
+		for j := 0; j < numsep; j++ {
+			key += RandStringBytes(10) + "/"
+		}
+		key += RandStringBytes(40)
+		testData[key] = RandStringBytes(100)
+	}
+
+}
+
+const letterBytes = "abcdef0123456789"
+
+func RandStringBytes(n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = letterBytes[rand.Intn(len(letterBytes))]
+	}
+	return string(b)
 }

--- a/basic_test.go
+++ b/basic_test.go
@@ -338,8 +338,18 @@ func TestAtomicWrite(t *testing.T) {
 	}
 }
 
+const letterBytes = "abcdef0123456789"
+
+func RandStringBytes(n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = letterBytes[rand.Intn(len(letterBytes))]
+	}
+	return string(b)
+}
+
 func TestHybridStore(t *testing.T) {
-	var regex *regexp.Regexp = regexp.MustCompile("[0-9a-fA-F]{64}")
+	regex := regexp.MustCompile("[0-9a-fA-F]{64}")
 
 	transformFunc := func(s string) *PathKey {
 
@@ -377,10 +387,10 @@ func TestHybridStore(t *testing.T) {
 
 	}
 	opts := Options{
-		BasePath:         "test-data",
-		CacheSizeMax:     1024,
-		Transform:        transformFunc,
-		InverseTransform: inverseTransformFunc,
+		BasePath:          "test-data",
+		CacheSizeMax:      1024,
+		AdvancedTransform: transformFunc,
+		InverseTransform:  inverseTransformFunc,
 	}
 	d := New(opts)
 	defer d.EraseAll()
@@ -405,14 +415,16 @@ func TestHybridStore(t *testing.T) {
 		testData[key] = RandStringBytes(100)
 	}
 
-}
-
-const letterBytes = "abcdef0123456789"
-
-func RandStringBytes(n int) string {
-	b := make([]byte, n)
-	for i := range b {
-		b[i] = letterBytes[rand.Intn(len(letterBytes))]
+	for k, v := range testData {
+		d.WriteString(k, v)
 	}
-	return string(b)
+
+	for k, v := range testData {
+		readVal := d.ReadString(k)
+
+		if v != readVal {
+			t.Fatalf("read: expected %s, got %s", v, readVal)
+		}
+	}
+
 }

--- a/basic_test.go
+++ b/basic_test.go
@@ -340,7 +340,7 @@ func TestAtomicWrite(t *testing.T) {
 
 const letterBytes = "abcdef0123456789"
 
-func RandStringBytes(n int) string {
+func randStringBytes(n int) string {
 	b := make([]byte, n)
 	for i := range b {
 		b[i] = letterBytes[rand.Intn(len(letterBytes))]
@@ -398,21 +398,21 @@ func TestHybridStore(t *testing.T) {
 	testData := map[string]string{}
 
 	for i := 0; i < 100; i++ {
-		testData[RandStringBytes(64)] = RandStringBytes(100)
+		testData[randStringBytes(64)] = randStringBytes(100)
 	}
 
 	for i := 0; i < 100; i++ {
-		testData[RandStringBytes(20)] = RandStringBytes(100)
+		testData[randStringBytes(20)] = randStringBytes(100)
 	}
 
 	for i := 0; i < 100; i++ {
 		numsep := rand.Intn(10) + 1
 		key := ""
 		for j := 0; j < numsep; j++ {
-			key += RandStringBytes(10) + "/"
+			key += randStringBytes(10) + "/"
 		}
-		key += RandStringBytes(40)
-		testData[key] = RandStringBytes(100)
+		key += randStringBytes(40)
+		testData[key] = randStringBytes(100)
 	}
 
 	for k, v := range testData {

--- a/diskv.go
+++ b/diskv.go
@@ -595,18 +595,6 @@ func (d *Diskv) walker(c chan<- string, prefix string, cancel <-chan struct{}) f
 			Path:     pathSplit,
 			FileName: file,
 		}
-		/* 		if info.IsDir() {
-		   			pathKey = &PathKey{
-		   				Path:     pathSplit,
-		   				FileName: "",
-		   			}
-		   		} else {
-
-		   			pathKey = &PathKey{
-		   				Path:     pathSplit,
-		   				FileName: file,
-		   			}
-				   } */
 
 		key := d.InverseTransform(pathKey)
 

--- a/diskv.go
+++ b/diskv.go
@@ -111,7 +111,7 @@ func New(o Options) *Diskv {
 		if o.Transform == nil {
 			o.AdvancedTransform = defaultAdvancedTransform
 		} else {
-			o.AdvancedTransform = convertToSimpleTransform(o.Transform)
+			o.AdvancedTransform = convertToAdvancedTransform(o.Transform)
 		}
 		o.InverseTransform = defaultInverseTransform
 	} else {
@@ -140,9 +140,9 @@ func New(o Options) *Diskv {
 	return d
 }
 
-// convertToSimpleTransform takes a classic Transform function and
+// convertToAdvancedTransform takes a classic Transform function and
 // converts it to the new AdvancedTransform
-func convertToSimpleTransform(oldFunc func(s string) []string) AdvancedTransformFunction {
+func convertToAdvancedTransform(oldFunc func(s string) []string) AdvancedTransformFunction {
 	return func(s string) *PathKey {
 		return &PathKey{Path: oldFunc(s), FileName: s}
 	}

--- a/diskv.go
+++ b/diskv.go
@@ -113,7 +113,9 @@ func New(o Options) *Diskv {
 		} else {
 			o.AdvancedTransform = convertToAdvancedTransform(o.Transform)
 		}
-		o.InverseTransform = defaultInverseTransform
+		if o.InverseTransform == nil {
+			o.InverseTransform = defaultInverseTransform
+		}
 	} else {
 		if o.InverseTransform == nil {
 			panic("You must provide an InverseTransform function in advanced mode")

--- a/diskv.go
+++ b/diskv.go
@@ -22,12 +22,19 @@ const (
 	defaultPathPerm os.FileMode = 0777
 )
 
+type PathKey struct {
+	Path        []string
+	FileName    string
+	originalKey string
+}
+
 var (
-	defaultTransform   = func(s string) []string { return []string{} }
-	errCanceled        = errors.New("canceled")
-	errEmptyKey        = errors.New("empty key")
-	errBadKey          = errors.New("bad key")
-	errImportDirectory = errors.New("can't import a directory")
+	defaultTransform        = func(s string) *PathKey { return &PathKey{Path: []string{}, FileName: s} }
+	defaultInverseTransform = func(pathKey *PathKey) string { return pathKey.FileName }
+	errCanceled             = errors.New("canceled")
+	errEmptyKey             = errors.New("empty key")
+	errBadKey               = errors.New("bad key")
+	errImportDirectory      = errors.New("can't import a directory")
 )
 
 // TransformFunction transforms a key into a slice of strings, with each
@@ -36,16 +43,19 @@ var (
 //
 // For example, if TransformFunc transforms "abcdef" to ["ab", "cde", "f"],
 // the final location of the data file will be <basedir>/ab/cde/f/abcdef
-type TransformFunction func(s string) []string
+type TransformFunction func(s string) *PathKey
+
+type InverseTransformFunction func(pathKey *PathKey) string
 
 // Options define a set of properties that dictate Diskv behavior.
 // All values are optional.
 type Options struct {
-	BasePath     string
-	Transform    TransformFunction
-	CacheSizeMax uint64 // bytes
-	PathPerm     os.FileMode
-	FilePerm     os.FileMode
+	BasePath         string
+	Transform        TransformFunction
+	InverseTransform InverseTransformFunction
+	CacheSizeMax     uint64 // bytes
+	PathPerm         os.FileMode
+	FilePerm         os.FileMode
 	// If TempDir is set, it will enable filesystem atomic writes by
 	// writing temporary files to that location before being moved
 	// to BasePath.
@@ -77,7 +87,13 @@ func New(o Options) *Diskv {
 	}
 	if o.Transform == nil {
 		o.Transform = defaultTransform
+		o.InverseTransform = defaultInverseTransform
 	}
+
+	if o.InverseTransform == nil {
+		panic("You must provide an InverseTransform function")
+	}
+
 	if o.PathPerm == 0 {
 		o.PathPerm = defaultPathPerm
 	}
@@ -98,11 +114,23 @@ func New(o Options) *Diskv {
 	return d
 }
 
+func SimpleTransform(oldFunc func(s string) []string) TransformFunction {
+	return func(s string) *PathKey {
+		return &PathKey{Path: oldFunc(s), FileName: s}
+	}
+}
+
 // Write synchronously writes the key-value pair to disk, making it immediately
 // available for reads. Write relies on the filesystem to perform an eventual
 // sync to physical media. If you need stronger guarantees, see WriteStream.
 func (d *Diskv) Write(key string, val []byte) error {
 	return d.WriteStream(key, bytes.NewReader(val), false)
+}
+
+func (d *Diskv) transform(key string) (pathKey *PathKey) {
+	pathKey = d.Transform(key)
+	pathKey.originalKey = key
+	return
 }
 
 // WriteStream writes the data represented by the io.Reader to the disk, under
@@ -115,20 +143,29 @@ func (d *Diskv) WriteStream(key string, r io.Reader, sync bool) error {
 		return errEmptyKey
 	}
 
+	pathKey := d.transform(key)
+
 	// Ensure keys cannot evaluate to paths that would not exist
-	if strings.ContainsRune(key, os.PathSeparator) {
+	for _, pathPart := range pathKey.Path {
+		if strings.ContainsRune(pathPart, os.PathSeparator) {
+			return errBadKey
+		}
+
+	}
+
+	if strings.ContainsRune(pathKey.FileName, os.PathSeparator) {
 		return errBadKey
 	}
 
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
-	return d.writeStreamWithLock(key, r, sync)
+	return d.writeStreamWithLock(pathKey, r, sync)
 }
 
 // createKeyFileWithLock either creates the key file directly, or
 // creates a temporary file in TempDir if it is set.
-func (d *Diskv) createKeyFileWithLock(key string) (*os.File, error) {
+func (d *Diskv) createKeyFileWithLock(pathKey *PathKey) (*os.File, error) {
 	if d.TempDir != "" {
 		if err := os.MkdirAll(d.TempDir, d.PathPerm); err != nil {
 			return nil, fmt.Errorf("temp mkdir: %s", err)
@@ -147,7 +184,7 @@ func (d *Diskv) createKeyFileWithLock(key string) (*os.File, error) {
 	}
 
 	mode := os.O_WRONLY | os.O_CREATE | os.O_TRUNC // overwrite if exists
-	f, err := os.OpenFile(d.completeFilename(key), mode, d.FilePerm)
+	f, err := os.OpenFile(d.completeFilename(pathKey), mode, d.FilePerm)
 	if err != nil {
 		return nil, fmt.Errorf("open file: %s", err)
 	}
@@ -155,12 +192,12 @@ func (d *Diskv) createKeyFileWithLock(key string) (*os.File, error) {
 }
 
 // writeStream does no input validation checking.
-func (d *Diskv) writeStreamWithLock(key string, r io.Reader, sync bool) error {
-	if err := d.ensurePathWithLock(key); err != nil {
+func (d *Diskv) writeStreamWithLock(pathKey *PathKey, r io.Reader, sync bool) error {
+	if err := d.ensurePathWithLock(pathKey); err != nil {
 		return fmt.Errorf("ensure path: %s", err)
 	}
 
-	f, err := d.createKeyFileWithLock(key)
+	f, err := d.createKeyFileWithLock(pathKey)
 	if err != nil {
 		return fmt.Errorf("create key file: %s", err)
 	}
@@ -199,18 +236,19 @@ func (d *Diskv) writeStreamWithLock(key string, r io.Reader, sync bool) error {
 		return fmt.Errorf("file close: %s", err)
 	}
 
-	if f.Name() != d.completeFilename(key) {
-		if err := os.Rename(f.Name(), d.completeFilename(key)); err != nil {
+	fullPath := d.completeFilename(pathKey)
+	if f.Name() != fullPath {
+		if err := os.Rename(f.Name(), fullPath); err != nil {
 			os.Remove(f.Name()) // error deliberately ignored
 			return fmt.Errorf("rename: %s", err)
 		}
 	}
 
 	if d.Index != nil {
-		d.Index.Insert(key)
+		d.Index.Insert(pathKey.originalKey)
 	}
 
-	d.bustCacheWithLock(key) // cache only on read
+	d.bustCacheWithLock(pathKey.originalKey) // cache only on read
 
 	return nil
 }
@@ -229,16 +267,18 @@ func (d *Diskv) Import(srcFilename, dstKey string, move bool) (err error) {
 		return errImportDirectory
 	}
 
+	dstPathKey := d.transform(dstKey)
+
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
-	if err := d.ensurePathWithLock(dstKey); err != nil {
+	if err := d.ensurePathWithLock(dstPathKey); err != nil {
 		return fmt.Errorf("ensure path: %s", err)
 	}
 
 	if move {
-		if err := syscall.Rename(srcFilename, d.completeFilename(dstKey)); err == nil {
-			d.bustCacheWithLock(dstKey)
+		if err := syscall.Rename(srcFilename, d.completeFilename(dstPathKey)); err == nil {
+			d.bustCacheWithLock(dstPathKey.originalKey)
 			return nil
 		} else if err != syscall.EXDEV {
 			// If it failed due to being on a different device, fall back to copying
@@ -251,7 +291,7 @@ func (d *Diskv) Import(srcFilename, dstKey string, move bool) (err error) {
 		return err
 	}
 	defer f.Close()
-	err = d.writeStreamWithLock(dstKey, f, false)
+	err = d.writeStreamWithLock(dstPathKey, f, false)
 	if err == nil && move {
 		err = os.Remove(srcFilename)
 	}
@@ -282,6 +322,8 @@ func (d *Diskv) Read(key string) ([]byte, error) {
 // If compression is enabled, ReadStream taps into the io.Reader stream prior
 // to decompression, and caches the compressed data.
 func (d *Diskv) ReadStream(key string, direct bool) (io.ReadCloser, error) {
+
+	pathKey := d.transform(key)
 	d.mu.RLock()
 	defer d.mu.RUnlock()
 
@@ -301,15 +343,15 @@ func (d *Diskv) ReadStream(key string, direct bool) (io.ReadCloser, error) {
 		}()
 	}
 
-	return d.readWithRLock(key)
+	return d.readWithRLock(pathKey)
 }
 
 // read ignores the cache, and returns an io.ReadCloser representing the
 // decompressed data for the given key, streamed from the disk. Clients should
 // acquire a read lock on the Diskv and check the cache themselves before
 // calling read.
-func (d *Diskv) readWithRLock(key string) (io.ReadCloser, error) {
-	filename := d.completeFilename(key)
+func (d *Diskv) readWithRLock(pathKey *PathKey) (io.ReadCloser, error) {
+	filename := d.completeFilename(pathKey)
 
 	fi, err := os.Stat(filename)
 	if err != nil {
@@ -326,7 +368,7 @@ func (d *Diskv) readWithRLock(key string) (io.ReadCloser, error) {
 
 	var r io.Reader
 	if d.CacheSizeMax > 0 {
-		r = newSiphon(f, d, key)
+		r = newSiphon(f, d, pathKey.originalKey)
 	} else {
 		r = &closingReader{f}
 	}
@@ -400,6 +442,7 @@ func (s *siphon) Read(p []byte) (int, error) {
 
 // Erase synchronously erases the given key from the disk and the cache.
 func (d *Diskv) Erase(key string) error {
+	pathKey := d.transform(key)
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
@@ -411,7 +454,7 @@ func (d *Diskv) Erase(key string) error {
 	}
 
 	// erase from disk
-	filename := d.completeFilename(key)
+	filename := d.completeFilename(pathKey)
 	if s, err := os.Stat(filename); err == nil {
 		if s.IsDir() {
 			return errBadKey
@@ -446,6 +489,7 @@ func (d *Diskv) EraseAll() error {
 
 // Has returns true if the given key exists.
 func (d *Diskv) Has(key string) bool {
+	pathKey := d.transform(key)
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
@@ -453,7 +497,7 @@ func (d *Diskv) Has(key string) bool {
 		return true
 	}
 
-	filename := d.completeFilename(key)
+	filename := d.completeFilename(pathKey)
 	s, err := os.Stat(filename)
 	if err != nil {
 		return false
@@ -481,11 +525,12 @@ func (d *Diskv) KeysPrefix(prefix string, cancel <-chan struct{}) <-chan string 
 	if prefix == "" {
 		prepath = d.BasePath
 	} else {
-		prepath = d.pathFor(prefix)
+		prefixKey := d.transform(prefix)
+		prepath = d.pathFor(prefixKey)
 	}
 	c := make(chan string)
 	go func() {
-		filepath.Walk(prepath, walker(c, prefix, cancel))
+		filepath.Walk(prepath, d.walker(c, prefix, cancel))
 		close(c)
 	}()
 	return c
@@ -493,18 +538,42 @@ func (d *Diskv) KeysPrefix(prefix string, cancel <-chan struct{}) <-chan string 
 
 // walker returns a function which satisfies the filepath.WalkFunc interface.
 // It sends every non-directory file entry down the channel c.
-func walker(c chan<- string, prefix string, cancel <-chan struct{}) filepath.WalkFunc {
+func (d *Diskv) walker(c chan<- string, prefix string, cancel <-chan struct{}) filepath.WalkFunc {
 	return func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
 
-		if info.IsDir() || !strings.HasPrefix(info.Name(), prefix) {
+		relPath, _ := filepath.Rel(d.BasePath, path)
+		dir, file := filepath.Split(relPath)
+		pathSplit := strings.Split(dir, string(filepath.Separator))
+		pathSplit = pathSplit[:len(pathSplit)-1]
+
+		pathKey := &PathKey{
+			Path:     pathSplit,
+			FileName: file,
+		}
+		/* 		if info.IsDir() {
+		   			pathKey = &PathKey{
+		   				Path:     pathSplit,
+		   				FileName: "",
+		   			}
+		   		} else {
+
+		   			pathKey = &PathKey{
+		   				Path:     pathSplit,
+		   				FileName: file,
+		   			}
+				   } */
+
+		key := d.InverseTransform(pathKey)
+
+		if info.IsDir() || !strings.HasPrefix(key, prefix) {
 			return nil // "pass"
 		}
 
 		select {
-		case c <- info.Name():
+		case c <- key:
 		case <-cancel:
 			return errCanceled
 		}
@@ -515,19 +584,19 @@ func walker(c chan<- string, prefix string, cancel <-chan struct{}) filepath.Wal
 
 // pathFor returns the absolute path for location on the filesystem where the
 // data for the given key will be stored.
-func (d *Diskv) pathFor(key string) string {
-	return filepath.Join(d.BasePath, filepath.Join(d.Transform(key)...))
+func (d *Diskv) pathFor(pathKey *PathKey) string {
+	return filepath.Join(d.BasePath, filepath.Join(pathKey.Path...))
 }
 
 // ensurePathWithLock is a helper function that generates all necessary
 // directories on the filesystem for the given key.
-func (d *Diskv) ensurePathWithLock(key string) error {
-	return os.MkdirAll(d.pathFor(key), d.PathPerm)
+func (d *Diskv) ensurePathWithLock(pathKey *PathKey) error {
+	return os.MkdirAll(d.pathFor(pathKey), d.PathPerm)
 }
 
 // completeFilename returns the absolute path to the file for the given key.
-func (d *Diskv) completeFilename(key string) string {
-	return filepath.Join(d.pathFor(key), key)
+func (d *Diskv) completeFilename(pathKey *PathKey) string {
+	return filepath.Join(d.pathFor(pathKey), pathKey.FileName)
 }
 
 // cacheWithLock attempts to cache the given key-value pair in the store's
@@ -569,7 +638,7 @@ func (d *Diskv) uncacheWithLock(key string, sz uint64) {
 // pruneDirsWithLock deletes empty directories in the path walk leading to the
 // key k. Typically this function is called after an Erase is made.
 func (d *Diskv) pruneDirsWithLock(key string) error {
-	pathlist := d.Transform(key)
+	pathlist := d.transform(key).Path
 	for i := range pathlist {
 		dir := filepath.Join(d.BasePath, filepath.Join(pathlist[:len(pathlist)-i]...))
 

--- a/examples/advanced-transform-2/advanced-transform-2.go
+++ b/examples/advanced-transform-2/advanced-transform-2.go
@@ -1,0 +1,80 @@
+package main
+
+/* This example uses a more advanced transform function that simulates a bit
+ how Git stores objects:
+
+* places hash-like keys under the objects directory
+* any other key is placed in the base directory. If the key
+* contains slashes, these are converted to subdirectories
+
+*/
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/peterbourgon/diskv"
+)
+
+var regex = regexp.MustCompile("[0-9a-fA-F]{40}")
+
+func AdvancedTransformExample(s string) *diskv.PathKey {
+
+	if regex.MatchString(s) {
+		return &diskv.PathKey{Path: []string{"objects", s[0:2]},
+			FileName: s,
+		}
+	}
+
+	folders := strings.Split(s, "/")
+	lfolders := len(folders)
+	if lfolders > 1 {
+		return &diskv.PathKey{Path: folders[:lfolders-1],
+			FileName: folders[lfolders-1],
+		}
+	}
+
+	return &diskv.PathKey{Path: []string{},
+		FileName: s,
+	}
+}
+
+func InverseTransformExample(pathKey *diskv.PathKey) string {
+
+	if regex.MatchString(pathKey.FileName) {
+		return pathKey.FileName
+	}
+
+	if len(pathKey.Path) == 0 {
+		return pathKey.FileName
+	}
+
+	return strings.Join(pathKey.Path, "/") + "/" + pathKey.FileName
+
+}
+
+func main() {
+
+	d := diskv.New(diskv.Options{
+		BasePath:          "my-data-dir",
+		AdvancedTransform: AdvancedTransformExample,
+		InverseTransform:  InverseTransformExample,
+		CacheSizeMax:      1024 * 1024,
+	})
+
+	// Write some text to the key "alpha/beta/gamma".
+	key := "1bd88421b055327fcc8660c76c4894c4ea4c95d7"
+	d.WriteString(key, "¡Hola!") // will be stored in "<basedir>/objects/1b/1bd88421b055327fcc8660c76c4894c4ea4c95d7"
+
+	d.WriteString("refs/heads/master", "some text") // will be stored in "<basedir>/refs/heads/master"
+
+	fmt.Println("Enumerating All keys:")
+	c := d.Keys(nil)
+
+	for key := range c {
+		value := d.ReadString(key)
+		fmt.Printf("Key: %s, Value: %s\n", key, value)
+	}
+
+}

--- a/examples/advanced-transform/advanced-transform.go
+++ b/examples/advanced-transform/advanced-transform.go
@@ -24,23 +24,18 @@ func InverseTransformExample(pathKey *diskv.PathKey) (key string) {
 	if txt != ".txt" {
 		panic("Invalid file found in storage folder!")
 	}
-	key = strings.Join(pathKey.Path, "/") + pathKey.FileName[:len(pathKey.FileName)-4]
-	return
+	return strings.Join(pathKey.Path, "/") + pathKey.FileName[:len(pathKey.FileName)-4]
 }
 
 func main() {
-
 	d := diskv.New(diskv.Options{
 		BasePath:          "my-data-dir",
 		AdvancedTransform: AdvancedTransformExample,
 		InverseTransform:  InverseTransformExample,
 		CacheSizeMax:      1024 * 1024,
 	})
-
 	// Write some text to the key "alpha/beta/gamma".
 	key := "alpha/beta/gamma"
 	d.WriteString(key, "¡Hola!") // will be stored in "<basedir>/alpha/beta/gamma.txt"
-
 	fmt.Println(d.ReadString("alpha/beta/gamma"))
-
 }

--- a/examples/advanced-transform/advanced-transform.go
+++ b/examples/advanced-transform/advanced-transform.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/peterbourgon/diskv"
+)
+
+func AdvancedTransformExample(key string) *diskv.PathKey {
+	path := strings.Split(key, "/")
+	last := len(path) - 1
+	return &diskv.PathKey{
+		Path:     path[:last],
+		FileName: path[last] + ".txt",
+	}
+}
+
+// If you provide an AdvancedTransform, you must also provide its
+// inverse:
+
+func InverseTransformExample(pathKey *diskv.PathKey) (key string) {
+	txt := pathKey.FileName[len(pathKey.FileName)-4:]
+	if txt != ".txt" {
+		panic("Invalid file found in storage folder!")
+	}
+	key = strings.Join(pathKey.Path, "/") + pathKey.FileName[:len(pathKey.FileName)-4]
+	return
+}
+
+func main() {
+
+	d := diskv.New(diskv.Options{
+		BasePath:          "my-data-dir",
+		AdvancedTransform: AdvancedTransformExample,
+		InverseTransform:  InverseTransformExample,
+		CacheSizeMax:      1024 * 1024,
+	})
+
+	// Write some text to the key "alpha/beta/gamma".
+	key := "alpha/beta/gamma"
+	d.WriteString(key, "¡Hola!") // will be stored in "<basedir>/alpha/beta/gamma.txt"
+
+	fmt.Println(d.ReadString("alpha/beta/gamma"))
+
+}

--- a/examples/git-like-store/git-like-store.go
+++ b/examples/git-like-store/git-like-store.go
@@ -17,11 +17,10 @@ import (
 	"github.com/peterbourgon/diskv"
 )
 
-var regex = regexp.MustCompile("[0-9a-fA-F]{40}")
+var hex40 = regexp.MustCompile("[0-9a-fA-F]{40}")
 
-func AdvancedTransformExample(s string) *diskv.PathKey {
-
-	if regex.MatchString(s) {
+func hexTransform(s string) *diskv.PathKey {
+	if hex40.MatchString(s) {
 		return &diskv.PathKey{Path: []string{"objects", s[0:2]},
 			FileName: s,
 		}
@@ -40,9 +39,8 @@ func AdvancedTransformExample(s string) *diskv.PathKey {
 	}
 }
 
-func InverseTransformExample(pathKey *diskv.PathKey) string {
-
-	if regex.MatchString(pathKey.FileName) {
+func hexInverseTransform(pathKey *diskv.PathKey) string {
+	if hex40.MatchString(pathKey.FileName) {
 		return pathKey.FileName
 	}
 
@@ -51,15 +49,13 @@ func InverseTransformExample(pathKey *diskv.PathKey) string {
 	}
 
 	return strings.Join(pathKey.Path, "/") + "/" + pathKey.FileName
-
 }
 
 func main() {
-
 	d := diskv.New(diskv.Options{
 		BasePath:          "my-data-dir",
-		AdvancedTransform: AdvancedTransformExample,
-		InverseTransform:  InverseTransformExample,
+		AdvancedTransform: hexTransform,
+		InverseTransform:  hexInverseTransform,
 		CacheSizeMax:      1024 * 1024,
 	})
 
@@ -76,5 +72,4 @@ func main() {
 		value := d.ReadString(key)
 		fmt.Printf("Key: %s, Value: %s\n", key, value)
 	}
-
 }

--- a/examples/super-simple-store/super-simple-store.go
+++ b/examples/super-simple-store/super-simple-store.go
@@ -9,7 +9,6 @@ import (
 func main() {
 	d := diskv.New(diskv.Options{
 		BasePath:     "my-diskv-data-directory",
-		Transform:    func(s string) []string { return []string{} },
 		CacheSizeMax: 1024 * 1024, // 1MB
 	})
 

--- a/index_test.go
+++ b/index_test.go
@@ -37,7 +37,6 @@ func (d *Diskv) isIndexed(key string) bool {
 func TestIndexOrder(t *testing.T) {
 	d := New(Options{
 		BasePath:     "index-test",
-		Transform:    func(string) []string { return []string{} },
 		CacheSizeMax: 1024,
 		Index:        &BTreeIndex{},
 		IndexLess:    strLess,
@@ -68,7 +67,6 @@ func TestIndexOrder(t *testing.T) {
 func TestIndexLoad(t *testing.T) {
 	d1 := New(Options{
 		BasePath:     "index-test",
-		Transform:    func(string) []string { return []string{} },
 		CacheSizeMax: 1024,
 	})
 	defer d1.EraseAll()
@@ -81,7 +79,6 @@ func TestIndexLoad(t *testing.T) {
 
 	d2 := New(Options{
 		BasePath:     "index-test",
-		Transform:    func(string) []string { return []string{} },
 		CacheSizeMax: 1024,
 		Index:        &BTreeIndex{},
 		IndexLess:    strLess,
@@ -129,7 +126,6 @@ func TestIndexLoad(t *testing.T) {
 func TestIndexKeysEmptyFrom(t *testing.T) {
 	d := New(Options{
 		BasePath:     "index-test",
-		Transform:    func(string) []string { return []string{} },
 		CacheSizeMax: 1024,
 		Index:        &BTreeIndex{},
 		IndexLess:    strLess,
@@ -150,7 +146,6 @@ func TestIndexKeysEmptyFrom(t *testing.T) {
 func TestBadKeys(t *testing.T) {
 	d := New(Options{
 		BasePath:     "index-test",
-		Transform:    func(string) []string { return []string{} },
 		CacheSizeMax: 1024,
 		Index:        &BTreeIndex{},
 		IndexLess:    strLess,

--- a/issues_test.go
+++ b/issues_test.go
@@ -13,7 +13,6 @@ import (
 func TestIssue2A(t *testing.T) {
 	d := New(Options{
 		BasePath:     "test-issue-2a",
-		Transform:    func(string) []string { return []string{} },
 		CacheSizeMax: 1024,
 	})
 	defer d.EraseAll()
@@ -56,9 +55,10 @@ func TestIssue2B(t *testing.T) {
 	}
 
 	d := New(Options{
-		BasePath:     "test-issue-2b",
-		Transform:    blockTransform,
-		CacheSizeMax: 0,
+		BasePath:         "test-issue-2b",
+		Transform:        SimpleTransform(blockTransform),
+		InverseTransform: defaultInverseTransform,
+		CacheSizeMax:     0,
 	})
 	defer d.EraseAll()
 

--- a/issues_test.go
+++ b/issues_test.go
@@ -55,10 +55,9 @@ func TestIssue2B(t *testing.T) {
 	}
 
 	d := New(Options{
-		BasePath:         "test-issue-2b",
-		Transform:        SimpleTransform(blockTransform),
-		InverseTransform: defaultInverseTransform,
-		CacheSizeMax:     0,
+		BasePath:     "test-issue-2b",
+		Transform:    blockTransform,
+		CacheSizeMax: 0,
 	})
 	defer d.EraseAll()
 

--- a/keys_test.go
+++ b/keys_test.go
@@ -1,12 +1,10 @@
-package diskv_test
+package diskv
 
 import (
 	"reflect"
 	"runtime"
 	"strings"
 	"testing"
-
-	"github.com/peterbourgon/diskv"
 )
 
 var (
@@ -49,9 +47,10 @@ func TestKeysFlat(t *testing.T) {
 		}
 		return []string{}
 	}
-	d := diskv.New(diskv.Options{
-		BasePath:  "test-data",
-		Transform: transform,
+	d := New(Options{
+		BasePath:         "test-data",
+		Transform:        SimpleTransform(transform),
+		InverseTransform: defaultInverseTransform,
 	})
 	defer d.EraseAll()
 
@@ -63,9 +62,10 @@ func TestKeysFlat(t *testing.T) {
 }
 
 func TestKeysNested(t *testing.T) {
-	d := diskv.New(diskv.Options{
-		BasePath:  "test-data",
-		Transform: blockTransform(2),
+	d := New(Options{
+		BasePath:         "test-data",
+		Transform:        SimpleTransform(blockTransform(2)),
+		InverseTransform: defaultInverseTransform,
 	})
 	defer d.EraseAll()
 
@@ -77,7 +77,7 @@ func TestKeysNested(t *testing.T) {
 }
 
 func TestKeysPrefixFlat(t *testing.T) {
-	d := diskv.New(diskv.Options{
+	d := New(Options{
 		BasePath: "test-data",
 	})
 	defer d.EraseAll()
@@ -92,9 +92,10 @@ func TestKeysPrefixFlat(t *testing.T) {
 }
 
 func TestKeysPrefixNested(t *testing.T) {
-	d := diskv.New(diskv.Options{
-		BasePath:  "test-data",
-		Transform: blockTransform(2),
+	d := New(Options{
+		BasePath:         "test-data",
+		Transform:        SimpleTransform(blockTransform(2)),
+		InverseTransform: defaultInverseTransform,
 	})
 	defer d.EraseAll()
 
@@ -108,7 +109,7 @@ func TestKeysPrefixNested(t *testing.T) {
 }
 
 func TestKeysCancel(t *testing.T) {
-	d := diskv.New(diskv.Options{
+	d := New(Options{
 		BasePath: "test-data",
 	})
 	defer d.EraseAll()
@@ -135,7 +136,7 @@ func TestKeysCancel(t *testing.T) {
 	}
 
 	if want, have := cancelAfter, received; want != have {
-		t.Errorf("want %d, have %d")
+		t.Errorf("want %d, have %d", want, have)
 	}
 }
 

--- a/keys_test.go
+++ b/keys_test.go
@@ -48,9 +48,8 @@ func TestKeysFlat(t *testing.T) {
 		return []string{}
 	}
 	d := New(Options{
-		BasePath:         "test-data",
-		Transform:        SimpleTransform(transform),
-		InverseTransform: defaultInverseTransform,
+		BasePath:  "test-data",
+		Transform: transform,
 	})
 	defer d.EraseAll()
 
@@ -63,9 +62,8 @@ func TestKeysFlat(t *testing.T) {
 
 func TestKeysNested(t *testing.T) {
 	d := New(Options{
-		BasePath:         "test-data",
-		Transform:        SimpleTransform(blockTransform(2)),
-		InverseTransform: defaultInverseTransform,
+		BasePath:  "test-data",
+		Transform: blockTransform(2),
 	})
 	defer d.EraseAll()
 
@@ -93,9 +91,8 @@ func TestKeysPrefixFlat(t *testing.T) {
 
 func TestKeysPrefixNested(t *testing.T) {
 	d := New(Options{
-		BasePath:         "test-data",
-		Transform:        SimpleTransform(blockTransform(2)),
-		InverseTransform: defaultInverseTransform,
+		BasePath:  "test-data",
+		Transform: blockTransform(2),
 	})
 	defer d.EraseAll()
 

--- a/speed_test.go
+++ b/speed_test.go
@@ -43,7 +43,6 @@ func benchRead(b *testing.B, size, cachesz int) {
 	b.StopTimer()
 	d := New(Options{
 		BasePath:     "speed-test",
-		Transform:    func(string) []string { return []string{} },
 		CacheSizeMax: uint64(cachesz),
 	})
 	defer d.EraseAll()
@@ -66,7 +65,6 @@ func benchWrite(b *testing.B, size int, withIndex bool) {
 
 	options := Options{
 		BasePath:     "speed-test",
-		Transform:    func(string) []string { return []string{} },
 		CacheSizeMax: 0,
 	}
 	if withIndex {


### PR DESCRIPTION
This PR adds the following support:

* slashes and other special characters in the key name: you now have the chance of filtering them out in your transform function
* convenient ReadString and WriteString methods
* updated test cases
* advanced key transformation examples