### PR TITLE
Read: always return nil slice on error

### DIFF
--- a/basic_test.go
+++ b/basic_test.go
@@ -49,6 +49,28 @@ func TestWriteReadErase(t *testing.T) {
 	}
 }
 
+func TestRead(t *testing.T) {
+	d := New(Options{
+		BasePath:     "test-data",
+		CacheSizeMax: 1024,
+	})
+	defer d.EraseAll()
+	k, v := "a", []byte(nil)
+	if err := d.Write(k, v); err != nil {
+		t.Fatalf("write: %s", err)
+	}
+	if readVal, err := d.Read(k); err != nil {
+		t.Fatalf("read: %s", err)
+	} else if len(readVal) > 0 || readVal == nil {
+		t.Fatalf("read: want an empty slice, got %v", readVal)
+	}
+	if readVal, err := d.Read("b"); err == nil {
+		t.Fatalf("read: want an error, got nil")
+	} else if readVal != nil {
+		t.Fatalf("read: want a nil slice, got %v", readVal)
+	}
+}
+
 func TestWRECache(t *testing.T) {
 	d := New(Options{
 		BasePath:     "test-data",

--- a/diskv.go
+++ b/diskv.go
@@ -338,10 +338,14 @@ func (d *Diskv) Import(srcFilename, dstKey string, move bool) (err error) {
 func (d *Diskv) Read(key string) ([]byte, error) {
 	rc, err := d.ReadStream(key, false)
 	if err != nil {
-		return []byte{}, err
+		return nil, err
 	}
 	defer rc.Close()
-	return ioutil.ReadAll(rc)
+	value, err := ioutil.ReadAll(rc)
+	if err != nil {
+		return nil, err
+	}
+	return value, err
 }
 
 // ReadString reads the key and returns a string value


### PR DESCRIPTION
This lets one more easily distinguish between a key that doesn't exist and an existing key with an empty value.