### PR TITLE
add mod file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/peterbourgon/diskv
+
+go 1.12
+
+require github.com/google/btree v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/google/btree v1.0.0 h1:0udJVsspx3VBr5FwtLhQQtuAsVc79tTq0ocGIPAU6qo=
+github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=


### PR DESCRIPTION
- [go modules](https://github.com/golang/go/wiki/Modules) will be enabled in 1.13
- `go mod tidy` was also run to include required dependencies
  - if you would like to only consume valid releases, this can block on:
    - [x] google/btree#30
- after merge it would be nice if you would tag this repo: e.g. `v2.0.2`
  - this will prevent indirect dependencies in consumer go.mod files