### PR TITLE
add mod file and bump major version

### DIFF
--- a/examples/advanced-transform/advanced-transform.go
+++ b/examples/advanced-transform/advanced-transform.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/peterbourgon/diskv"
+	"github.com/peterbourgon/diskv/v3"
 )
 
 func AdvancedTransformExample(key string) *diskv.PathKey {

--- a/examples/content-addressable-store/cas.go
+++ b/examples/content-addressable-store/cas.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/peterbourgon/diskv"
+	"github.com/peterbourgon/diskv/v3"
 )
 
 const transformBlockSize = 2 // grouping of chars per directory depth

--- a/examples/git-like-store/git-like-store.go
+++ b/examples/git-like-store/git-like-store.go
@@ -14,7 +14,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/peterbourgon/diskv"
+	"github.com/peterbourgon/diskv/v3"
 )
 
 var hex40 = regexp.MustCompile("[0-9a-fA-F]{40}")

--- a/examples/super-simple-store/super-simple-store.go
+++ b/examples/super-simple-store/super-simple-store.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/peterbourgon/diskv"
+	"github.com/peterbourgon/diskv/v3"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/peterbourgon/diskv/v3
+
+go 1.12
+
+require github.com/google/btree v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/google/btree v1.0.0 h1:0udJVsspx3VBr5FwtLhQQtuAsVc79tTq0ocGIPAU6qo=
+github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=

--- a/import_test.go
+++ b/import_test.go
@@ -5,7 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 
-	"github.com/peterbourgon/diskv"
+	"github.com/peterbourgon/diskv/v3"
 
 	"testing"
 )


### PR DESCRIPTION
- continuation of module change from #52
- since your release tags are v2+ simply adding a go.mod file will cause
`v2.0.0+incompatible` versions in consumers
  - the go authors suggest bumping the major version to resolve this:
https://github.com/golang/go/wiki/Modules#incrementing-the-major-version-when-first-adopting-modules-with-v2-packages
    - after merge you should tag this repo with `v3.0.0`
  - you could migrate to `v2.1.0`, but this could cause consumer
breakage
  - this uses the major branch paradigm, but you could leverage major
subdirectory instead:
https://github.com/golang/go/wiki/Modules#releasing-modules-v2-or-higher