### PR TITLE
Fix issue #40

### DIFF
--- a/diskv.go
+++ b/diskv.go
@@ -630,6 +630,9 @@ func (d *Diskv) completeFilename(pathKey *PathKey) string {
 // cacheWithLock attempts to cache the given key-value pair in the store's
 // cache. It can fail if the value is larger than the cache's maximum size.
 func (d *Diskv) cacheWithLock(key string, val []byte) error {
+	// If the key already exists, delete it.
+	d.bustCacheWithLock(key)
+
 	valueSize := uint64(len(val))
 	if err := d.ensureCacheSpaceWithLock(valueSize); err != nil {
 		return fmt.Errorf("%s; not caching", err)


### PR DESCRIPTION
When we call ReadStream, it checks if the desired value is in the cache and if not calls readWithRLock, which returns a diskv.siphon. The siphon will write to the cache *when it gets an EOF from the file on disk*.

If we call ReadStream twice on the same key, we get two siphon objects, both of which will write to the cache when they finish reading. However, the cacheWithLock function does not check if the key it has been told to cache already exists in the cache. If the key already exists, cacheWithLock blithely overwrites it (`d.cache[key] = val`) and then improperly adds to the cache size (`d.cacheSize += valueSize`).

This patch makes cacheWithLock blow away any existing cached value before it writes into the cache. Benchmarks show no noticeable difference.

Fixes #40 