### PR TITLE
Update README.md: Use version tag v3 in `go get` command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Install [Go 1][3], either [from source][4] or [with a prepackaged binary][5].
 Then,
 
 ```bash
-$ go get github.com/peterbourgon/diskv
+$ go get github.com/peterbourgon/diskv/v3
 ```
 
 [3]: http://golang.org


### PR DESCRIPTION
Update README.md: Use version tag v3 in `go get` command.

Sorry i didn't realize there're 2 URLs in README and only one was fixed in last PR. This PR fixes the remained one.

Also, the links used in README.md seems broken, you may want to fix it manually.
```
[![Build Status][1]][2]

[1]: https://drone.io/github.com/peterbourgon/diskv/status.png
[2]: https://drone.io/github.com/peterbourgon/diskv/latest
```